### PR TITLE
Add query and mutations to notification service

### DIFF
--- a/prisma/datamodel.graphql
+++ b/prisma/datamodel.graphql
@@ -38,7 +38,7 @@ type Email {
   subject: String!
   body: String!
   status: Status!
-  send_error: String
+  sendError: String
   html: Boolean! @default(value:"false")
 }
 

--- a/src/generated/prisma.graphql
+++ b/src/generated/prisma.graphql
@@ -31,7 +31,7 @@ type Email {
   subject: String!
   body: String!
   status: Status!
-  send_error: String
+  sendError: String
   html: Boolean!
 }
 
@@ -47,7 +47,7 @@ input EmailCreateInput {
   subject: String!
   body: String!
   status: Status!
-  send_error: String
+  sendError: String
   html: Boolean
 }
 
@@ -74,8 +74,8 @@ enum EmailOrderByInput {
   body_DESC
   status_ASC
   status_DESC
-  send_error_ASC
-  send_error_DESC
+  sendError_ASC
+  sendError_DESC
   html_ASC
   html_DESC
   createdAt_ASC
@@ -91,7 +91,7 @@ type EmailPreviousValues {
   subject: String!
   body: String!
   status: Status!
-  send_error: String
+  sendError: String
   html: Boolean!
 }
 
@@ -119,7 +119,7 @@ input EmailUpdateDataInput {
   subject: String
   body: String
   status: Status
-  send_error: String
+  sendError: String
   html: Boolean
 }
 
@@ -129,7 +129,7 @@ input EmailUpdateInput {
   subject: String
   body: String
   status: Status
-  send_error: String
+  sendError: String
   html: Boolean
 }
 
@@ -139,7 +139,7 @@ input EmailUpdateManyMutationInput {
   subject: String
   body: String
   status: Status
-  send_error: String
+  sendError: String
   html: Boolean
 }
 
@@ -232,20 +232,20 @@ input EmailWhereInput {
   status_not: Status
   status_in: [Status!]
   status_not_in: [Status!]
-  send_error: String
-  send_error_not: String
-  send_error_in: [String!]
-  send_error_not_in: [String!]
-  send_error_lt: String
-  send_error_lte: String
-  send_error_gt: String
-  send_error_gte: String
-  send_error_contains: String
-  send_error_not_contains: String
-  send_error_starts_with: String
-  send_error_not_starts_with: String
-  send_error_ends_with: String
-  send_error_not_ends_with: String
+  sendError: String
+  sendError_not: String
+  sendError_in: [String!]
+  sendError_not_in: [String!]
+  sendError_lt: String
+  sendError_lte: String
+  sendError_gt: String
+  sendError_gte: String
+  sendError_contains: String
+  sendError_not_contains: String
+  sendError_starts_with: String
+  sendError_not_starts_with: String
+  sendError_ends_with: String
+  sendError_not_ends_with: String
   html: Boolean
   html_not: Boolean
   AND: [EmailWhereInput!]

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -1,15 +1,36 @@
 const {copyValueToObjectIfDefined, propertyExists} = require("./helper/objectHelper");
 const { UserInputError } = require("apollo-server");
 
+async function createNotification(_, args, context, info){
 
-// Mutation functions get listed below
+  if (args.email == undefined && args.online == undefined){
+    throw new Error("A notification must be created with either Email or Online information")
+  }
+
+  var createNotificationData = {
+    gcID: args.gcID,
+    appID: args.appID,
+    actionLink: copyValueToObjectIfDefined(args.actionLink),
+    actionLevel: args.actionLevel
+  };
+
+  if(args.online !== undefined){
+    createNotificationData.online = {
+      create: {
+        titleEn: args.online.titleEn,
+        titleFr: args.online.titleFr,
+        descriptionEn: args.online.descriptionEn,
+        descriptionFr: args.online.descriptionFr
+      }
+    }
+  }
 
 
-
-
-
-// Export the functions below to be included through client facing graphQL interface
+  return await context.prisma.mutation.createNotification({
+       data: createNotificationData,
+       }, info);
+}
 
 module.exports = {
-
+  createNotification
 };

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -4,7 +4,7 @@ const { UserInputError } = require("apollo-server");
 async function createNotification(_, args, context, info){
 
   if (!propertyExists(args, "online") && !propertyExists(args, "email")){
-    throw new Error("A notification must be created with either Email or Online information")
+    throw new Error("A notification must be created with either Email or Online information");
   }
 
   var createNotificationData = {
@@ -23,7 +23,7 @@ async function createNotification(_, args, context, info){
         descriptionEn: args.online.descriptionEn,
         descriptionFr: args.online.descriptionFr
       }
-    }
+    };
   }
 
   //create email notification
@@ -34,12 +34,12 @@ async function createNotification(_, args, context, info){
       subject: args.email.subject,
       body: args.email.body,
       html: args.email.html
-    }
+    };
 
-    const send_error = false; // TODO: Mail function that returns status of email and error if email can not be sent.
+    const sendError = false; // TODO: Mail function that returns status of email and error if email can not be sent.
 
-    if(send_error !== false){
-      createNotificationData.email.send_error = send_error;
+    if(sendError !== false){
+      createNotificationData.email.sendError = sendError;
       createNotificationData.email.status = "Queued";
     } else {
       createNotificationData.email.status = "Sent";
@@ -53,9 +53,9 @@ async function createNotification(_, args, context, info){
         body: createNotificationData.email.body,
         html: createNotificationData.email.html,
         status: createNotificationData.email.status,
-        send_error: createNotificationData.email.send_error
+        sendError: createNotificationData.email.sendError
       }
-    }
+    };
   }
 
   //who caused the notification
@@ -66,7 +66,7 @@ async function createNotification(_, args, context, info){
         teamID: args.whoDunIt.teamID,
         organizationID: args.whoDunIt.organizationID
       }
-    }
+    };
   }
 
   return await context.prisma.mutation.createNotification({
@@ -86,8 +86,8 @@ async function updateNotification(_, args, context, info){
     }
   );
 
-  if(notification == null | undefined) {
-    throw new UserInputError('Could not find notification with id: ' + args.id);
+  if(notification === null || typeof notification == "undefined") {
+    throw new UserInputError("Could not find notification with id: " + args.id);
   }
 
   var updateOnline = {

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -70,10 +70,47 @@ async function createNotification(_, args, context, info){
   }
 
   return await context.prisma.mutation.createNotification({
-       data: createNotificationData,
-       }, info);
+    data: createNotificationData,
+  }, info);
+}
+
+
+
+async function updateNotification(_, args, context, info){
+
+  const notification = await context.prisma.query.notification(
+    {
+      where:{
+        id: args.id
+      }
+    }
+  );
+
+  if(notification == null | undefined) {
+    throw new UserInputError('Could not find notification with id: ' + args.id);
+  }
+
+  var updateOnline = {
+    online: {
+      update: {
+        titleEn: copyValueToObjectIfDefined(args.online.titleEn),
+        titleFr: copyValueToObjectIfDefined(args.online.titleFr),
+        descriptionEn: copyValueToObjectIfDefined(args.online.descriptionEn),
+        descriptionFr: copyValueToObjectIfDefined(args.online.descriptionFr),
+        viewed: copyValueToObjectIfDefined(args.online.viewed)
+      }
+    }
+  };
+
+  return await context.prisma.mutation.updateNotification({
+    where: {
+      id: args.id
+    },
+    data: updateOnline,
+  }, info);
 }
 
 module.exports = {
-  createNotification
+  createNotification,
+  updateNotification
 };

--- a/src/resolvers/Mutations.js
+++ b/src/resolvers/Mutations.js
@@ -3,7 +3,7 @@ const { UserInputError } = require("apollo-server");
 
 async function createNotification(_, args, context, info){
 
-  if (args.email == undefined && args.online == undefined){
+  if (!propertyExists(args, "online") && !propertyExists(args, "email")){
     throw new Error("A notification must be created with either Email or Online information")
   }
 
@@ -14,7 +14,8 @@ async function createNotification(_, args, context, info){
     actionLevel: args.actionLevel
   };
 
-  if(args.online !== undefined){
+  //create online notification
+  if(propertyExists(args, "online")){
     createNotificationData.online = {
       create: {
         titleEn: args.online.titleEn,
@@ -25,6 +26,48 @@ async function createNotification(_, args, context, info){
     }
   }
 
+  //create email notification
+  if(propertyExists(args, "email")){
+    createNotificationData.email = {
+      from: args.email.from,
+      to: args.email.to,
+      subject: args.email.subject,
+      body: args.email.body,
+      html: args.email.html
+    }
+
+    const send_error = false; // TODO: Mail function that returns status of email and error if email can not be sent.
+
+    if(send_error !== false){
+      createNotificationData.email.send_error = send_error;
+      createNotificationData.email.status = "Queued";
+    } else {
+      createNotificationData.email.status = "Sent";
+    }
+
+    createNotificationData.email = {
+      create: {
+        from: createNotificationData.email.from,
+        to: createNotificationData.email.to,
+        subject: createNotificationData.email.subject,
+        body: createNotificationData.email.body,
+        html: createNotificationData.email.html,
+        status: createNotificationData.email.status,
+        send_error: createNotificationData.email.send_error
+      }
+    }
+  }
+
+  //who caused the notification
+  if(propertyExists(args, "whoDunIt")){
+    createNotificationData.whoDunIt = {
+      create: {
+        gcID: args.whoDunIt.gcID,
+        teamID: args.whoDunIt.teamID,
+        organizationID: args.whoDunIt.organizationID
+      }
+    }
+  }
 
   return await context.prisma.mutation.createNotification({
        data: createNotificationData,

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -1,12 +1,20 @@
 const {copyValueToObjectIfDefined} = require("./helper/objectHelper");
 const { addFragmentToInfo } = require("graphql-binding");
 
-// Query functions get listed below
+function notifications(_, args, context, info) {
+  return context.prisma.query.notifications(
+    {
+      where:{
+        gcID: args.gcID,
+        appID: copyValueToObjectIfDefined(args.appID)
+      },
+      skip: copyValueToObjectIfDefined(args.skip),
+      first: copyValueToObjectIfDefined(args.first),
+    },
+    info
+  );
+}
 
-
-
-
-// Export Query functions for inclusion in client facing graphQL interface
 module.exports = {
-
+  notifications
 };

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -8,9 +8,6 @@ function notifications(_, args, context, info) {
         gcID: args.gcID,
         appID: copyValueToObjectIfDefined(args.appID),
         actionLevel:  copyValueToObjectIfDefined(args.actionLevel),
-        online: {
-          viewed: copyValueToObjectIfDefined(args.viewed)
-        },
       },
       skip: copyValueToObjectIfDefined(args.skip),
       first: copyValueToObjectIfDefined(args.first),

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -7,7 +7,10 @@ function notifications(_, args, context, info) {
       where:{
         gcID: args.gcID,
         appID: copyValueToObjectIfDefined(args.appID),
-        actionLevel:  copyValueToObjectIfDefined(args.actionLevel)
+        actionLevel:  copyValueToObjectIfDefined(args.actionLevel),
+        online: {
+          viewed: copyValueToObjectIfDefined(args.viewed)
+        },
       },
       skip: copyValueToObjectIfDefined(args.skip),
       first: copyValueToObjectIfDefined(args.first),

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -6,7 +6,8 @@ function notifications(_, args, context, info) {
     {
       where:{
         gcID: args.gcID,
-        appID: copyValueToObjectIfDefined(args.appID)
+        appID: copyValueToObjectIfDefined(args.appID),
+        actionLevel:  copyValueToObjectIfDefined(args.actionLevel)
       },
       skip: copyValueToObjectIfDefined(args.skip),
       first: copyValueToObjectIfDefined(args.first),

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,7 +4,7 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(gcID: String!, appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]! #@isAuthenticated
+    notifications(gcID: String!, appID: String, actionLevel: String, viewed: Boolean, skip: Int, first: Int): [Notification!]! #@isAuthenticated
 }
 
 type Mutation{

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,27 +4,25 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(gcID: String!, appID: String, viewed: Boolean, skip: Int, first: Int): [Notification!]!
+    notifications(gcID: String!, appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]!
 }
 
 type Mutation{
-    createNotification(gcID: String!, appID: String!, actionLink: String, actionLevel: actionLevel!, email: EmailInput, online: OnlineInput): Notification
-    updateNotification(id: ID!, online: UpdateOnlineInput): Notification
-
+    createNotification(gcID: String!, appID: String!, actionLink: String, actionLevel: actionLevel!, email: EmailInput, online: OnlineInput, whoDunIt: whoDunItInput): Notification
 }
 
-enum actionLevel {
+enum actionLevel{
   NoUserAction
   Featured
   UserActionRequired
 }
 
-enum Status {
+enum Status{
   Sent
   Queued
 }
 
-type Notification {
+type Notification{
   id: ID!
   gcID: String!
   appID: String!
@@ -35,7 +33,7 @@ type Notification {
   whoDunIt: whoDunIt
 }
 
-type whoDunIt {
+type whoDunIt{
   gcID: String!
   teamID: String
   organizationID: String
@@ -44,7 +42,7 @@ type whoDunIt {
 
 type Email{
     from: String!
-    to: [String!]!
+    to: String!
     subject: String!
     body: String!
     status: Status!
@@ -61,7 +59,7 @@ type Online{
 }
 input EmailInput{
     from: String!
-    to: [String!]!
+    to: String!
     subject: String!
     body: String!
     html: Boolean
@@ -80,4 +78,10 @@ input UpdateOnlineInput{
     descriptionEn: String
     descriptionFr: String
     viewed: Boolean
+}
+
+input whoDunItInput{
+  gcID: String!
+  teamID: String
+  organizationID: String
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,11 +4,12 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(gcID: String!, appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]!
+    notifications(gcID: String!, appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]! #@isAuthenticated
 }
 
 type Mutation{
-    createNotification(gcID: String!, appID: String!, actionLink: String, actionLevel: actionLevel!, email: EmailInput, online: OnlineInput, whoDunIt: whoDunItInput): Notification
+    createNotification(gcID: String!, appID: String!, actionLink: String, actionLevel: actionLevel!, email: EmailInput, online: OnlineInput, whoDunIt: whoDunItInput): Notification! #@isAuthenticated
+    updateNotification(id: ID!, online: UpdateOnlineInput): Notification! #@isAuthenticated
 }
 
 enum actionLevel{
@@ -28,7 +29,7 @@ type Notification{
   appID: String!
   actionLink: String
   actionLevel: actionLevel!
-  email: Email
+  email: Email # @isAppCreatorOwner TODO: Make isAppCreatorOwner directive
   online: Online
   whoDunIt: whoDunIt
 }
@@ -81,7 +82,7 @@ input UpdateOnlineInput{
 }
 
 input whoDunItInput{
-  gcID: String!
+  gcID: String
   teamID: String
   organizationID: String
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,11 +4,11 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(gcID: String!, appId: String, viewed: Boolean, skip: Int, first: Int): [Notification!]!
+    notifications(gcID: String!, appID: String, viewed: Boolean, skip: Int, first: Int): [Notification!]!
 }
 
 type Mutation{
-    createNotification(gcID:String!, email: EmailInput, online: OnlineInput): Notification
+    createNotification(gcID: String!, appID: String!, actionLink: String, actionLevel: actionLevel!, email: EmailInput, online: OnlineInput): Notification
     updateNotification(id: ID!, online: UpdateOnlineInput): Notification
 
 }
@@ -49,7 +49,7 @@ type Email{
     body: String!
     status: Status!
     send_error: String
-    html: Boolean! 
+    html: Boolean!
 }
 
 type Online{

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,7 +4,7 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(gcID: String!, appID: String, actionLevel: String, viewed: Boolean, skip: Int, first: Int): [Notification!]! #@isAuthenticated
+    notifications(gcID: String!, appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]! #@isAuthenticated
 }
 
 type Mutation{

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -47,7 +47,7 @@ type Email{
     subject: String!
     body: String!
     status: Status!
-    send_error: String
+    sendError: String
     html: Boolean!
 }
 


### PR DESCRIPTION
# Description

Created the createNotification and updateNotification mutations and the notifications query. 

Notifications query requires a valid gcID to query but offers the ability to filter based on appID, actionLevel, and viewed status.

CreateNotification mutation requires a gcID, appID, actionLevel, and either online or email input to run.
UpdateNotification mutation requires a notification id to run and modify any of the notification's online fields.

Also included comments on where to progress with Auth directives moving forward based on security model discussion.

Closes https://zube.io/tbs-sct/gctools/c/3893 https://zube.io/tbs-sct/gctools/c/3892

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tests included creating a notification, querying notifications and updating a notification. All test were run in the graphql playground.

- [x] Ran createNotification mutation without the email and online fields filled out and received the proper response of "A notification must be created with either Email or Online information". From there filling in either email or online fields would then create the notification.
- [x] Ran updateNotification mutation with invalid notification id and received correct error response back. With a valid notification id, mutation can successfully change the title, description and viewed status of an online notification.
- [x]  Was able to run notifications query with valid gcID to receive notifications generated for that user. Was able to add additional options like appID, actionLevel and viewed status to filter notifications. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
