### PR TITLE
Ability to filter notifications by viewed status and by newest/oldest

### DIFF
--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -1,4 +1,4 @@
-const {copyValueToObjectIfDefined} = require("./helper/objectHelper");
+const {copyValueToObjectIfDefined, propertyExists} = require("./helper/objectHelper");
 const { addFragmentToInfo } = require("graphql-binding");
 
 function notifications(_, args, context, info) {
@@ -8,9 +8,13 @@ function notifications(_, args, context, info) {
         gcID: context.token.sub,
         appID: copyValueToObjectIfDefined(args.appID),
         actionLevel:  copyValueToObjectIfDefined(args.actionLevel),
+        online: {
+          viewed: copyValueToObjectIfDefined(args.viewed),
+        },
       },
       skip: copyValueToObjectIfDefined(args.skip),
       first: copyValueToObjectIfDefined(args.first),
+      orderBy: copyValueToObjectIfDefined(args.orderBy),
     },
     info
   );

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4,7 +4,7 @@
 directive @isAuthenticated on OBJECT | FIELD_DEFINITION
 
 type Query{
-    notifications(appID: String, actionLevel: String, skip: Int, first: Int): [Notification!]! @isAuthenticated
+    notifications(appID: String, actionLevel: String, viewed: Boolean skip: Int, first: Int, orderBy: OrderByInput): [Notification!]! @isAuthenticated
 }
 
 type Mutation{
@@ -21,6 +21,11 @@ enum actionLevel{
 enum Status{
   Sent
   Queued
+}
+
+enum OrderByInput {
+  generatedOn_DESC
+  generatedOn_ASC
 }
 
 type Notification{


### PR DESCRIPTION
# Description

Update notification query to be able to query notifications based on online.viewed status and provide an option to order the returning notifications by ASC/DESC
Fixes # (issue)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
